### PR TITLE
Fix closeDbChannel error

### DIFF
--- a/src/components/data-workflows/common/listing/ListingComponent.vue
+++ b/src/components/data-workflows/common/listing/ListingComponent.vue
@@ -146,7 +146,8 @@ export default class ListingComponent extends Vue {
 
 	@Watch('$route.name')
 	async onRouteNameChanged() {
-		await this.$store.dispatch(`${this.moduleName}/closeDBChannel`);
+		// _identifier is not existing to properly close channel (Discussed with Luca)
+		await this.$store.dispatch(`${this.moduleName}/closeDBChannel`, { _identifier: 'none' });
 	}
 
 	private firestoreItems: any;


### PR DESCRIPTION
## Related issue(s)
<!--
Link your pull request to an issue using a keyword:
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Closes #306


## Description
<!-- Describe globally your PR in its context -->
This PR fixes `closeDbChannel` error. This was fixed in a meeting with Luca & source code of the library was explained.
You can access to the [source code](https://github.com/mesqueeb/vuex-easy-firestore/blob/dev/src/module/actions.ts#L933
) of the `closeDbChannel`.


## What does this PR do?
<!-- List all stuff that have been done -->
- [ ] Add `none` identifier.


## Deploy notes
<!-- Add additional instructions is necessary to deploy this PR -->
Review & merge.


## Steps to test or reproduce
<!-- List different steps to approve your PR -->
1. Go to a runs listing view.
2. Switch to a new account
3. Go to the same runs listing view => Results should be there with no error thrown.